### PR TITLE
005 refactoring logger wrapper

### DIFF
--- a/dealership_review/utils/logger.py
+++ b/dealership_review/utils/logger.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-function-docstring,no-self-use
 
-import logging
 import os
 
 
@@ -17,25 +16,22 @@ class Logger:
     Wrapper for a logger class
     """
 
-    def __init__(self):
-        logging.basicConfig(format='### %(levelname)s /// %(message)s')
-
     @avoid_log_on_test
     def debug(self, message):
-        logging.debug(message)
+        print(f'### DEBUG /// {message}')
 
     @avoid_log_on_test
     def info(self, message):
-        logging.info(message)
+        print(f'### INFO /// {message}')
 
     @avoid_log_on_test
     def warning(self, message):
-        logging.warning(message)
+        print(f'### WARNING /// {message}')
 
     @avoid_log_on_test
     def error(self, message):
-        logging.error(message)
+        print(f'### ERROR /// {message}')
 
     @avoid_log_on_test
     def critical(self, message):
-        logging.critical(message)
+        print(f'### CRITICAL /// {message}')

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -16,35 +16,35 @@ class TestLogger(unittest.TestCase):
     def setUp(self) -> None:
         os.environ['ENV'] = 'test_logger'
 
-    @patch('logging.debug')
-    def test_debug(self, mocked_debug):
+    @patch('builtins.print')
+    def test_debug(self, mocked_print):
         Logger().debug('debug')
 
-        mocked_debug.assert_called_with('debug')
+        mocked_print.assert_called_with('### DEBUG /// debug')
 
-    @patch('logging.info')
-    def test_info(self, mocked_info):
+    @patch('builtins.print')
+    def test_info(self, mocked_print):
         Logger().info('info')
 
-        mocked_info.assert_called_with('info')
+        mocked_print.assert_called_with('### INFO /// info')
 
-    @patch('logging.warning')
-    def test_warning(self, mocked_warning):
+    @patch('builtins.print')
+    def test_warning(self, mocked_print):
         Logger().warning('warning')
 
-        mocked_warning.assert_called_with('warning')
+        mocked_print.assert_called_with('### WARNING /// warning')
 
-    @patch('logging.error')
-    def test_error(self, mocked_error):
+    @patch('builtins.print')
+    def test_error(self, mocked_print):
         Logger().error('error')
 
-        mocked_error.assert_called_with('error')
+        mocked_print.assert_called_with('### ERROR /// error')
 
-    @patch('logging.critical')
-    def test_critical(self, mocked_critical):
+    @patch('builtins.print')
+    def test_critical(self, mocked_print):
         Logger().critical('critical')
 
-        mocked_critical.assert_called_with('critical')
+        mocked_print.assert_called_with('### CRITICAL /// critical')
 
     def tearDown(self) -> None:
         os.environ['ENV'] = 'test'


### PR DESCRIPTION
## Changes

Decided to use builtin `print` instead of `logging` package

### Checklist

 - [x] Tests
 - [x] Documentation
